### PR TITLE
PDF creation fails if no 'head_of_meeting' is selected.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,10 @@ Changelog
 - Fix JS toggling of meeting content.
   [treinhard]
 
+- Avoid exception with PDF generation if 'head_of_meeting'
+  (or another field that uses a vocabulary) is empty.
+  [treinhard]
+
 
 1.4.2 (2013-03-11)
 ------------------

--- a/ftw/meeting/latex/views.py
+++ b/ftw/meeting/latex/views.py
@@ -128,6 +128,8 @@ class MeetingView(RecursiveLaTeXView):
 
         vocabulary = field.Vocabulary(self.context)
         if vocabulary:
+            if not value:
+                return ''
             return self.convert(self.context.displayValue(vocabulary, value))
         elif not value:
             return ''


### PR DESCRIPTION
The check could probably be merged with the one two lines further down by moving it above of the enclosing "if".
