### PR TITLE
Ignore removed users in PDF.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.11 (unreleased)
 -------------------
 
+- Ignore removed users in PDF.
+  [jone]
+
 - Fix ftw.zipexport integration: make it optional on ZCML level.
   [jone]
 

--- a/ftw/meeting/latex/views.py
+++ b/ftw/meeting/latex/views.py
@@ -14,11 +14,16 @@ def get_value_from_vocab(vocabulary, value):
     if hasattr(value, '__iter__'):
         vocab_value = []
         for val in value:
-            vocab_value.append(vocabulary.getValue(val))
+            label = vocabulary.getValue(val)
+            if label is not None:
+                vocab_value.append(label)
         return ', '.join(vocab_value)
 
     else:
-        return vocabulary.getValue(value)
+        label = vocabulary.getValue(value)
+        if label is None:
+            label = ''
+        return label
 
 
 class MeetingView(RecursiveLaTeXView):
@@ -137,16 +142,17 @@ class MeetingView(RecursiveLaTeXView):
         field = self.context.getField(fieldname)
         value = field.get(self.context)
 
+        if not value:
+            return ''
+
         vocabulary = field.Vocabulary(self.context)
         if vocabulary:
-            if not value:
-                return ''
             return self.convert(get_value_from_vocab(vocabulary, value))
 
-        elif not value:
-            return ''
-        else:
-            return self.convert(value)
+        if not isinstance(value, (str, unicode)):
+            value = str(value)
+
+        return self.convert(value)
 
     def _translate_metadata_labels(self, metadata):
         new_metadata = []

--- a/ftw/meeting/tests/test_latex_meeting_view.py
+++ b/ftw/meeting/tests/test_latex_meeting_view.py
@@ -146,6 +146,37 @@ class TestMeetingView(TestCase):
 
         view.render()
 
+    def test_with_deleted_head_of_meeting_user(self):
+        self.meeting.setMeeting_type('meeting')
+        self.meeting.setHead_of_meeting('deleted-user')
+        view = getMultiAdapter(
+            (self.meeting, self.meeting.REQUEST, self.layout), ILaTeXView)
+        view.render()
+
+    def test_with_deleted_recording_secretary_user(self):
+        self.meeting.setMeeting_type('meeting')
+        self.meeting.setRecording_secretary('deleted-user')
+        view = getMultiAdapter(
+            (self.meeting, self.meeting.REQUEST, self.layout), ILaTeXView)
+        view.render()
+
+    def test_with_deleted_attendee_user(self):
+        self.meeting.setMeeting_type('meeting')
+        self.meeting.setAttendees([{'contact': 'deleted-user',
+                                    'present': 'present'}])
+        view = getMultiAdapter(
+            (self.meeting, self.meeting.REQUEST, self.layout), ILaTeXView)
+        view.render()
+
+    def test_with_deleted_responsible_user_on_meeting_item(self):
+        create(Builder('meeting item')
+               .titled('Foo')
+               .having(responsibility=('deleted-user',))
+               .within(self.meeting))
+        view = getMultiAdapter(
+            (self.meeting, self.meeting.REQUEST, self.layout), ILaTeXView)
+        view.render()
+
     def test_meetingview_get_value_from_vocab(self):
         meeting = create(Builder('meeting')
                          .titled('Meeting')


### PR DESCRIPTION
Ignores users which are no longer available by making all vocabulary lookups safe.

@maethu 
