### PR TITLE
BugFix: Show "related_items" instead of "relatedItems" in meeting item l...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
+- BugFix: Show "related_items" instead of "relatedItems" in meeting item listing.
+  [mathias.leimgruber]
+
 - Also export references of meeting item on zip export on a meeting.
   [mathias.leimgruber]
 

--- a/ftw/meeting/tests/test_meeting_view.py
+++ b/ftw/meeting/tests/test_meeting_view.py
@@ -1,0 +1,34 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.meeting.interfaces import IMeetingLayer
+from ftw.meeting.testing import FTW_MEETING_INTEGRATION_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from unittest2 import TestCase
+from zope.interface import alsoProvides
+
+
+class TestMeetingRepresentation(TestCase):
+
+    layer = FTW_MEETING_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        request = self.layer['request']
+        alsoProvides(request, IMeetingLayer)
+
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_meeting_view_get_related_items(self):
+        file_ = create(Builder('file'))
+        meeting = create(Builder('meeting'))
+        meetingitem = create(Builder('meeting item')
+                             .having(related_items=file_)
+                             .within(meeting))
+
+        meetingview = meeting.restrictedTraverse('@@meeting_view')
+        brains = meetingview.get_related_items(meetingitem)
+        self.assertEquals([file_], [brain.getObject() for brain in brains])


### PR DESCRIPTION
...isting.

The implementation is basically a copy of the default implementation in `plone.app.layout.viewlets.content.ContentRelatedItems`, but in our case we have `related_items` field instead of a `relatedItems` field.

@jone 
