### PR TITLE
Render related items of the meeting in the PDF.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Render the related items of meeting objects.
+  [mbaechtold]
 
 
 1.5.2 (2014-07-31)

--- a/ftw/meeting/latex/templates/meeting.tex
+++ b/ftw/meeting/latex/templates/meeting.tex
@@ -28,6 +28,15 @@
 }
 </%block>
 
+% if relatedItems:
+  \subsection*{${_(u"latex_related_items", default=u"Related Items")}:}
+  \begin{itemize}
+  % for item in relatedItems:
+    \item{${item}}
+  % endfor
+  \end{itemize}
+% endif
+
 <%block name="content">
 ${latex_content}
 </%block>

--- a/ftw/meeting/latex/views.py
+++ b/ftw/meeting/latex/views.py
@@ -36,13 +36,17 @@ class MeetingView(RecursiveLaTeXView):
         meeting = self.context
         args = super(MeetingView, self).get_render_arguments()
 
-        args.update({
+        args.update(
+            {
                 '_': lambda *a, **kw: translate(_(*a, **kw),
                                                 context=self.request),
                 'title': meeting.Title(),
                 'meetingForm': '',
                 'metadata': self.get_metadata(),
-                'meetingItems': None})
+                'meetingItems': None,
+                'relatedItems': self.get_related_items(),
+            }
+        )
 
         if meeting.getMeeting_type() == 'meeting':
             args['meetingForm'] = self._get_meeting_value('meeting_form')
@@ -135,6 +139,18 @@ class MeetingView(RecursiveLaTeXView):
         for item in self.context.getFolderContents(
             contentFilter={'portal_type': ['Meeting Item']}):
             items.append(self.convert(item.Title))
+
+        return items
+
+    def get_related_items(self):
+        items = []
+
+        for obj in self.context.getRelated_items():
+            items.append(
+                self.convert(
+                    '<a href="%s">%s</a>' % (obj.absolute_url(), obj.Title())
+                )
+            )
 
         return items
 

--- a/ftw/meeting/tests/test_latex_meeting_view.py
+++ b/ftw/meeting/tests/test_latex_meeting_view.py
@@ -92,9 +92,9 @@ class TestMeetingView(TestCase):
              'title': 'THE event',
              'meetingForm': '',
              'metadata': [
-                    (u'Start', 'Aug 20, 2010 08:00 AM'),
-                    (u'End', 'Aug 22, 2010 04:00 PM'),
-                    (u'Location', 'Switzerland')],
+                 (u'Start', 'Aug 20, 2010 08:00 AM'),
+                 (u'End', 'Aug 22, 2010 04:00 PM'),
+                 (u'Location', 'Switzerland')],
              'meetingItems': None})
 
         view.render()
@@ -133,15 +133,15 @@ class TestMeetingView(TestCase):
              'title': 'THE meeting',
              'meetingForm': 'Protokoll',
              'metadata': [
-                    (u'Start', 'Aug 20, 2010 08:00 AM'),
-                    (u'End', 'Aug 22, 2010 04:00 PM'),
-                    (u'Location', 'Berne'),
-                    (u'Head of meeting', 'Doe John'),
-                    (u'Recording secretary', 'Boss Hugo'),
-                    ('', ''),
-                    (u'Attendees', 'Boss Hugo, present \\newline '
-                                   'Doe John, present'),
-                    ('', '')],
+                 (u'Start', 'Aug 20, 2010 08:00 AM'),
+                 (u'End', 'Aug 22, 2010 04:00 PM'),
+                 (u'Location', 'Berne'),
+                 (u'Head of meeting', 'Doe John'),
+                 (u'Recording secretary', 'Boss Hugo'),
+                 ('', ''),
+                 (u'Attendees', 'Boss Hugo, present \\newline '
+                                'Doe John, present'),
+                 ('', '')],
              'meetingItems': ['Foo', 'Bar']})
 
         view.render()

--- a/ftw/meeting/tests/test_latex_meeting_view.py
+++ b/ftw/meeting/tests/test_latex_meeting_view.py
@@ -79,6 +79,9 @@ class TestMeetingView(TestCase):
         self.meeting.setEnd_date(DateTime('08/22/2010 16:00'))
         self.meeting.setLocation('Switzerland')
 
+        task = create(Builder('task').titled('Easy task'))
+        self.meeting.setRelated_items([task])
+
         view = getMultiAdapter(
             (self.meeting, self.meeting.REQUEST, self.layout), ILaTeXView)
 
@@ -95,7 +98,13 @@ class TestMeetingView(TestCase):
                  (u'Start', 'Aug 20, 2010 08:00 AM'),
                  (u'End', 'Aug 22, 2010 04:00 PM'),
                  (u'Location', 'Switzerland')],
-             'meetingItems': None})
+             'meetingItems': None,
+             'relatedItems': [
+                 '\\href{http://nohost/plone/easy-task}''{Easy task'
+                 '\\footnote{'
+                 '\\href{http://nohost/plone/easy-task}{'
+                 '\\url{http://nohost/plone/easy-task}}}}'
+             ]})
 
         view.render()
 
@@ -114,6 +123,9 @@ class TestMeetingView(TestCase):
                                    'present': 'present'},
                                   {'contact': self.user1.getId(),
                                    'present': 'present'}])
+
+        task = create(Builder('task').titled('Easy task'))
+        self.meeting.setRelated_items([task])
 
         create(Builder('meeting item').titled('Foo').within(self.meeting))
         create(Builder('meeting item').titled('Bar').within(self.meeting))
@@ -142,7 +154,13 @@ class TestMeetingView(TestCase):
                  (u'Attendees', 'Boss Hugo, present \\newline '
                                 'Doe John, present'),
                  ('', '')],
-             'meetingItems': ['Foo', 'Bar']})
+             'meetingItems': ['Foo', 'Bar'],
+             'relatedItems': [
+                 '\\href{http://nohost/plone/easy-task}''{Easy task'
+                 '\\footnote{'
+                 '\\href{http://nohost/plone/easy-task}{'
+                 '\\url{http://nohost/plone/easy-task}}}}'
+             ]})
 
         view.render()
 


### PR DESCRIPTION
If a meeting object has related items, they should be rendered too.
This is already implemented for the related items of the meeting items.