### PR TITLE
Fix invalid css.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix invalid css, removing an unneeded closing curly bracket.
+  The CSS of 1.6.0 is invalid
+  [jone]
 
 
 1.6.0 (2015-05-11)

--- a/ftw/meeting/browser/styles/meeting.css
+++ b/ftw/meeting/browser/styles/meeting.css
@@ -89,4 +89,3 @@ ul.AttendeesListing li {
 #calendar.fc div.attendee {
   border-color: rgb(117, 173, 10);
 }
-}


### PR DESCRIPTION
Removing an unneeded closing curly bracket, making the CSS invalid.

The Problem was introduced with #41, released already in 1.6.0.

@maethu 
/cc @shylux 