### PR TITLE
fix layout for images in meetingitems.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Layout for Images in MeetingItems.
+  [tschanzt]
 
 
 1.6.1 (2015-05-13)

--- a/ftw/meeting/browser/meeting.pt
+++ b/ftw/meeting/browser/meeting.pt
@@ -300,23 +300,8 @@
                                 </table>
                             </div>
                         </div>
-
-                        <tr class="even" tal:repeat="meeting_item_file python:obj.getFolderContents({'portal_type':['File'], 'sort_on' : 'effective', 'sort_order' : 'descending'}, full_objects=True)">
-                            <td>&nbsp;</td>
-                            <td>
-                                <a href="#" tal:attributes="href string:${meeting_item_file/absolute_url}/download"
-                                   tal:content="meeting_item_file/title_or_id" />
-                                <div tal:content="meeting_item_file/Description" />
-                                <div tal:content="structure meeting_item_file/text" />
-                                <div tal:content="meeting_item_file/Creator" />
-                            </td>
-                            <td>&nbsp;</td>
-                            <td>&nbsp;</td>
-                            <td>&nbsp;</td>
-                        </tr>
                     </tal:block>
                 </div>
-
                 <table tal:define="files view/getFiles" tal:condition="files" class="listing" width="100%">
                     <tr>
                         <th width="*" i18n:translate="">Attachments</th>

--- a/ftw/meeting/browser/styles/meeting.css
+++ b/ftw/meeting/browser/styles/meeting.css
@@ -89,3 +89,7 @@ ul.AttendeesListing li {
 #calendar.fc div.attendee {
   border-color: rgb(117, 173, 10);
 }
+
+.MeetingItemBody img {
+    max-width: 100%;
+}


### PR DESCRIPTION
This PR limtits the width to 100% and removes the display of contained files, since we can't add normal files and images are displayed inline.
@jone 