### PR TITLE
Use E-Mail address in ics header instead of userid for the INDIVIDUAL property

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Use E-Mail address in ics header instead of userid for the INDIVIDUAL property. [mathias.leimgruber]
+
 - Drop Plone 4.1 support. [jone]
 
 - An older ftw.calendar is required because of breaking changes in

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Drop Plone 4.2 support. [mathias.leimgruber]
+
 - Use E-Mail address in ics header instead of userid for the INDIVIDUAL property. [mathias.leimgruber]
 
 - Drop Plone 4.1 support. [jone]

--- a/ftw/meeting/browser/export_ics.py
+++ b/ftw/meeting/browser/export_ics.py
@@ -1,6 +1,7 @@
+from plone import api
 from plone.memoize import ram
-from Products.ATContentTypes.lib import calendarsupport as cs
 from Products.ATContentTypes.browser.calendar import CalendarView, cachekey
+from Products.ATContentTypes.lib import calendarsupport as cs
 
 
 class ExportICS(CalendarView):
@@ -18,9 +19,11 @@ class ExportICS(CalendarView):
                 info = voc.getValue(attendee['contact'])
                 if not info:
                     continue
+
+                user = api.user.get(userid=attendee['contact'])
                 value += 'ATTENDEE;CN="%s";CUTYPE=INDIVIDUAL:%s\n' % (
                     info.decode('utf8'),
-                    attendee['contact'])
+                    user.getProperty('email'))
             return value.encode('utf8')
         return ''
 

--- a/ftw/meeting/tests/test_ics_attachment.py
+++ b/ftw/meeting/tests/test_ics_attachment.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.meeting.attachment import ICSAttachmentCreator
 from ftw.meeting.testing import FTW_MEETING_INTEGRATION_TESTING
 from plone.app.testing import setRoles, login
@@ -10,14 +12,16 @@ class TestIcsAttachmentView(unittest.TestCase):
 
     layer = FTW_MEETING_INTEGRATION_TESTING
 
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+        self.portal.invokeFactory('Folder', 'test')
+        self.test = self.portal['test']
+
     def test_ics_attachment(self):
-        portal = self.layer['portal']
-        setRoles(portal, TEST_USER_ID, ['Manager'])
-        login(portal, TEST_USER_NAME)
-        portal.invokeFactory('Folder', 'test')
-        test = portal['test']
-        test.invokeFactory('Meeting', 'meeting')
-        meeting = test['meeting']
+        self.test.invokeFactory('Meeting', 'meeting')
+        meeting = self.test['meeting']
         meeting.title = "TheMeeting"
         meeting.start_date = DateTime.DateTime()
         meeting.end_date = meeting.start_date + 1
@@ -28,3 +32,17 @@ class TestIcsAttachmentView(unittest.TestCase):
         self.assertIn("URL:http://nohost/plone/test/meeting", ics_data)
         self.assertIn("BEGIN:VALARM\r\nTRIGGER:-PT30M\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\nEND:VALARM",
                       ics_data)
+
+    def test_attendee_email_address_in_ics(self):
+        user = create(Builder('user').named('User', 'Test')
+                      .with_userid('test.user')
+                      .having(email='test@example.com'))
+        meeting = create(Builder('meeting')
+                         .having(attendees=[{'contact': user.getId(),
+                                             'present': 'present'}],
+                                 start_date=DateTime.DateTime(),
+                                 end_date=DateTime.DateTime() + 10))
+
+        ics = ICSAttachmentCreator(meeting)(meeting)
+        ics_data = ics[0][0].read()
+        self.assertIn('INDIVIDUAL:test@example.com', ics_data)

--- a/ftw/meeting/tests/test_ics_attachment.py
+++ b/ftw/meeting/tests/test_ics_attachment.py
@@ -1,15 +1,15 @@
-from ftw.meeting.testing import FTW_MEETING_INTEGRATION_TESTING
 from ftw.meeting.attachment import ICSAttachmentCreator
-import unittest2 as unittest
-from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
+from ftw.meeting.testing import FTW_MEETING_INTEGRATION_TESTING
 from plone.app.testing import setRoles, login
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
 import DateTime
+import unittest2 as unittest
 
 
 class TestIcsAttachmentView(unittest.TestCase):
-    
+
     layer = FTW_MEETING_INTEGRATION_TESTING
-    
+
     def test_ics_attachment(self):
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ['Manager'])
@@ -25,5 +25,6 @@ class TestIcsAttachmentView(unittest.TestCase):
         ics = creator(meeting)
         ics_data = ics[0][0].read()
         self.assertEqual("SUMMARY:TheMeeting" in ics_data, True)
-        self.assertEqual("URL:http://nohost/plone/test/meeting" in ics_data, True)
-        self.assertEqual("BEGIN:VALARM\r\nTRIGGER:-PT30M\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\nEND:VALARM" in ics_data, True)
+        self.assertIn("URL:http://nohost/plone/test/meeting", ics_data)
+        self.assertIn("BEGIN:VALARM\r\nTRIGGER:-PT30M\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\nEND:VALARM",
+                      ics_data)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(name='ftw.meeting',
         'ftw.calendarwidget',
         'plone.principalsource',
         'ftw.upgrade',
+        'plone.api',
         ],
 
       tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(name='ftw.meeting',
       # http://www.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-package-name = ftw.meeting


### PR DESCRIPTION
The vocab returns the User fullname as title and the userid as token/value. 

This PR gets the actual email address from the user.