### PR TITLE
Add organizer to calendar (.ics) file

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add organizer to calendar export file. [busykoala]
 
 
 1.7.0 (2019-03-12)

--- a/ftw/meeting/browser/export_ics.py
+++ b/ftw/meeting/browser/export_ics.py
@@ -1,7 +1,7 @@
-from plone import api
-from plone.memoize import ram
 from Products.ATContentTypes.browser.calendar import CalendarView, cachekey
 from Products.ATContentTypes.lib import calendarsupport as cs
+from plone import api
+from plone.memoize import ram
 
 
 class ExportICS(CalendarView):
@@ -37,7 +37,26 @@ class ExportICS(CalendarView):
         for brain in self.events:
             lines = brain.getObject().getICal().split('\n')
             lines.insert(1, self.attendees(brain))
+            # add organizer of event (head_of_meeting) if there is one
+            name_and_email = self.get_name_and_email_of_head_of_meeting(brain)
+            if name_and_email:
+                head_of_meeting_name = name_and_email[0]
+                head_of_meeting_email = name_and_email[1]
+                lines.insert(1, 'ORGANIZER;CN={}:MAILTO:{}'.format(
+                    head_of_meeting_name, head_of_meeting_email))
             data += '\n'.join(lines)
 
         data += cs.ICS_FOOTER
         return data
+
+    @staticmethod
+    def get_name_and_email_of_head_of_meeting(brain):
+        meeting = brain.getObject()
+        if not meeting.head_of_meeting:
+            # handle if there isn't any organizer
+            return None
+        user_id = meeting.head_of_meeting[0]
+        user = api.user.get(userid=user_id)
+        attendees = meeting.getAttendeesVocabulary()
+
+        return attendees.getValue(user_id), user.getProperty('email')

--- a/ftw/meeting/tests/test_ics_attachment.py
+++ b/ftw/meeting/tests/test_ics_attachment.py
@@ -37,12 +37,18 @@ class TestIcsAttachmentView(unittest.TestCase):
         user = create(Builder('user').named('User', 'Test')
                       .with_userid('test.user')
                       .having(email='test@example.com'))
+
+        head_of_meeting = create(Builder('user').named('Head', 'Meeting')
+                                 .with_userid('head.meeting')
+                                 .having(email='head-of-meeting@example.com'))
         meeting = create(Builder('meeting')
                          .having(attendees=[{'contact': user.getId(),
                                              'present': 'present'}],
                                  start_date=DateTime.DateTime(),
-                                 end_date=DateTime.DateTime() + 10))
+                                 end_date=DateTime.DateTime() + 10,
+                                 head_of_meeting=head_of_meeting.getId()))
 
         ics = ICSAttachmentCreator(meeting)(meeting)
         ics_data = ics[0][0].read()
         self.assertIn('INDIVIDUAL:test@example.com', ics_data)
+        self.assertIn('ORGANIZER;CN=Meeting Head:MAILTO:head-of-meeting@example.com', ics_data)


### PR DESCRIPTION
Close https://github.com/4teamwork/ogb/issues/9

There is a strange behaviour in Outlook 2013 when there is no organizer.
A button appears to update the event making the person updating it
automatically a organizer for all people to which the update is sent.
To prevent that we can add the organizer to the file explicitely and only
a button to save the date appears.